### PR TITLE
Allow downgrading of apt on Debian

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -28,6 +28,7 @@
   apt:
     name: opensips
     state: present
+    allow_downgrade: yes
   notify:
     - opensips start
     - opensips restart


### PR DESCRIPTION
This enables the ability to swap to the selected version even if it is lower